### PR TITLE
feat: Migrate from stdio to docker deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dev = [
     "pre-commit>=3.3.0",
     "bandit>=1.7.0",
     "safety>=2.3.0",
+    "fastapi>=0.100.0",
+    "respx>=0.20.0",
 ]
 security = [
     "cryptography>=41.0.0",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,12 +1,8 @@
 # Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
 
 startCommand:
-  type: stdio
+  type: docker
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: object
-  commandFunction:
-    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
-    |-
-    (config) => ({command: 'python', args: ['-m', 'skyfi_mcp_server.server']})
   exampleConfig: {}


### PR DESCRIPTION
### **User description**
This commit migrates the Smithery deployment configuration from STDIO to a Docker-based HTTP deployment.

The `smithery.yaml` file has been updated to change the `startCommand.type` from `stdio` to `docker`. This leverages the existing `Dockerfile` which correctly builds and runs the application in HTTP mode.

Additionally, missing test dependencies (`fastapi` and `respx`) were added to `pyproject.toml` to fix the test suite setup.


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate deployment from stdio to docker configuration

- Add missing test dependencies for FastAPI and HTTP testing

- Remove stdio-specific command function configuration

- Simplify smithery.yaml deployment setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stdio deployment"] --> B["docker deployment"]
  C["missing test deps"] --> D["added fastapi & respx"]
  B --> E["simplified config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add missing test dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>fastapi>=0.100.0</code> to dev dependencies<br> <li> Add <code>respx>=0.20.0</code> to dev dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/ngoiyaeric/SkyFi-MCP-server/pull/6/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smithery.yaml</strong><dd><code>Migrate to docker deployment type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

smithery.yaml

<ul><li>Change <code>startCommand.type</code> from <code>stdio</code> to <code>docker</code><br> <li> Remove <code>commandFunction</code> configuration block<br> <li> Simplify deployment configuration structure</ul>


</details>


  </td>
  <td><a href="https://github.com/ngoiyaeric/SkyFi-MCP-server/pull/6/files#diff-504f7098e133a347168e2cb914d66da5c6ee7b53b6e9c452d600c3ee7bc9c475">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added development-only dependencies: FastAPI (>=0.100.0) and respx (>=0.20.0).
- Refactor
  - Updated the service startup method to use Docker instead of a stdio-based launch, removing inline command generation. Users now start the service via Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->